### PR TITLE
Correct behaviour for 'useEffect()' with supabase server component

### DIFF
--- a/app/supabase-provider.tsx
+++ b/app/supabase-provider.tsx
@@ -21,15 +21,20 @@ export default function SupabaseProvider({
   const router = useRouter()
 
   useEffect(() => {
-    const {
-      data: { subscription }
-    } = supabase.auth.onAuthStateChange((event) => {
-      if (event === 'SIGNED_IN') router.refresh()
-    })
+    const getSupabase = async () => {
 
-    return () => {
-      subscription.unsubscribe()
+      const { data: { subscription } } = await supabase.auth.onAuthStateChange((event) => {
+      if (event === 'SIGNED_IN')
+        router.refresh()
+      })
+
+      return () => {
+        subscription.unsubscribe()
+      }
     }
+
+    getSupabase()
+
   }, [router, supabase])
 
   return (


### PR DESCRIPTION
## What is the current behavior?

```
'use client'

import type { Database } from '@/types_db'
import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs'
import type { SupabaseClient } from '@supabase/auth-helpers-nextjs'
import { useRouter } from 'next/navigation'
import { createContext, useContext, useEffect, useState } from 'react'

type SupabaseContext = {
  supabase: SupabaseClient<Database>;
}

const Context = createContext<SupabaseContext | undefined>(undefined)

export default function SupabaseProvider({
  children
}: {
  children: React.ReactNode
}) {
  const [supabase] = useState(() => createPagesBrowserClient())
  const router = useRouter()

  useEffect(() => {
    const {
      data: { subscription }
    } = supabase.auth.onAuthStateChange((event) => {
      if (event === 'SIGNED_IN') router.refresh()
    })

    return () => {
      subscription.unsubscribe()
    }
  }, [router, supabase])

  return (
    <Context.Provider value={{ supabase }}>
      <>{children}</>
    </Context.Provider>
  )
}

export const useSupabase = () => {
  const context = useContext(Context)

  if (context === undefined) {
    throw new Error('useSupabase must be used inside SupabaseProvider')
  }

  return context
}
```

## What is the new behavior?

```
'use client'

import type { Database } from '@/types_db'
import { createPagesBrowserClient } from '@supabase/auth-helpers-nextjs'
import type { SupabaseClient } from '@supabase/auth-helpers-nextjs'
import { useRouter } from 'next/navigation'
import { createContext, useContext, useEffect, useState } from 'react'

type SupabaseContext = {
  supabase: SupabaseClient<Database>;
}

const Context = createContext<SupabaseContext | undefined>(undefined)

export default function SupabaseProvider({
  children
}: {
  children: React.ReactNode
}) {
  const [supabase] = useState(() => createPagesBrowserClient())
  const router = useRouter()

  useEffect(() => {
    const getSupabase = async () => {

      const { data: { subscription } } = await supabase.auth.onAuthStateChange((event) => {
      if (event === 'SIGNED_IN')
        router.refresh()
      })

      return () => {
        subscription.unsubscribe()
      }
    }

    getSupabase()

  }, [router, supabase])

  return (
    <Context.Provider value={{ supabase }}>
      <>{children}</>
    </Context.Provider>
  )
}

export const useSupabase = () => {
  const context = useContext(Context)

  if (context === undefined) {
    throw new Error('useSupabase must be used inside SupabaseProvider')
  }

  return context
}

```


