### PR TITLE
Fixed some metadata tags

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,8 +5,8 @@ import { Metadata } from 'next'
 
 export const metadata: Metadata  = {
   title: {
-    default: '%s | StoneyDSP',
-    template: 'StoneyDSP',
+    default: 'StoneyDSP',
+    template: '%s | StoneyDSP',
   },
   applicationName: 'StoneyDSP',
   description: 'Systems, Web, Audio & Graphics',
@@ -25,7 +25,7 @@ export const metadata: Metadata  = {
   },
   openGraph: {
     title: 'StoneyDSP.com',
-    description: 'The React Framework for the Web',
+    description: 'Systems, Web, Audio & Graphics',
     url: 'https://www.stoneydsp.com',
     siteName: 'StoneyDSP.com',
     images: [


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix meta tags for 'og:description' and the 'title' template.

## What is the current behavior?

```
<title>%s | StoneyDSP</title>
...
<meta property="og:description" content="The React Framework for the Web"/>
```

## What is the new behavior?

```
<title>Login | StoneyDSP</title>
...
<meta property="og:description" content="Systems, Web, Audio & Graphics"/>
```
