### PR TITLE
Preview/analytics consent

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import { Header, Footer, Main, ConsentBanner } from '@/components/elements'
-import { Analytics } from '@vercel/analytics/server'
+import Analytics from '@vercel/analytics'
 // import Favicon from '@/app/favicon.ico'
 import { Metadata } from 'next'
 import { Suspense } from 'react'

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,9 +21,9 @@ export default function RootLayout({
           <Main>
             {children}
           </Main>
-          <ConsentBanner />
           <Footer />
         </Suspense>
+        <ConsentBanner />
         {/* <GoogleTagManager gtmId="GTM-WCM3NS5C" /> */}
         <Analytics
           beforeSend={(event) => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import { Header, Footer, Main, ConsentBanner } from '@/components/elements'
-import { Analytics } from '@vercel/analytics/react'
+import { Analytics } from '@vercel/analytics/server'
 // import Favicon from '@/app/favicon.ico'
 import { Metadata } from 'next'
 import { Suspense } from 'react'

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
+'use client'
 import { Header, Footer, Main, ConsentBanner } from '@/components/elements'
-import Analytics from '@vercel/analytics'
+import { Analytics } from '@vercel/analytics/react'
 // import Favicon from '@/app/favicon.ico'
 import { Metadata } from 'next'
 import { Suspense } from 'react'

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,3 @@
-'use client'
 import { Header, Footer, Main, ConsentBanner } from '@/components/elements'
 import { Analytics } from '@vercel/analytics/react'
 // import Favicon from '@/app/favicon.ico'
@@ -21,11 +20,10 @@ export default function RootLayout({
           <Header title={'Home'} />
           <Main>
             {children}
+            <ConsentBanner />
           </Main>
           <Footer />
         </Suspense>
-        <ConsentBanner />
-        {/* <GoogleTagManager gtmId="GTM-WCM3NS5C" /> */}
         <Analytics
           beforeSend={(event) => {
             if (localStorage.getItem('va-disable')) {
@@ -35,6 +33,7 @@ export default function RootLayout({
           }}
         />
       </body>
+      {/* <GoogleTagManager gtmId="GTM-WCM3NS5C" /> */}
     </html>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Header, Footer, Main } from '@/components/elements'
+import { Header, Footer, Main, ConsentBanner } from '@/components/elements'
 import { Analytics } from '@vercel/analytics/react'
 // import Favicon from '@/app/favicon.ico'
 import { Metadata } from 'next'
@@ -21,10 +21,18 @@ export default function RootLayout({
           <Main>
             {children}
           </Main>
+          <ConsentBanner />
           <Footer />
         </Suspense>
         {/* <GoogleTagManager gtmId="GTM-WCM3NS5C" /> */}
-        <Analytics />
+        <Analytics
+          beforeSend={(event) => {
+            if (localStorage.getItem('va-disable')) {
+              return null;
+            }
+            return event;
+          }}
+        />
       </body>
     </html>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import { Header, Footer, Main, ConsentBanner } from '@/components/elements'
-import { Analytics } from '@vercel/analytics/react'
+// import { Analytics } from '@vercel/analytics/react'
 // import Favicon from '@/app/favicon.ico'
 import { Metadata } from 'next'
 import { Suspense } from 'react'
@@ -24,14 +24,14 @@ export default function RootLayout({
           </Main>
           <Footer />
         </Suspense>
-        <Analytics
+        {/* <Analytics
           beforeSend={(event) => {
             if (localStorage.getItem('va-disable')) {
               return null;
             }
             return event;
           }}
-        />
+        /> */}
       </body>
       {/* <GoogleTagManager gtmId="GTM-WCM3NS5C" /> */}
     </html>

--- a/components/elements/banner/consent.tsx
+++ b/components/elements/banner/consent.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import { Analytics } from '@vercel/analytics/react'
 
 export default function ConsentBanner() {
 
@@ -47,6 +48,14 @@ export default function ConsentBanner() {
       >
         Decline cookies
       </button>
+      <Analytics
+        beforeSend={(event) => {
+          if (localStorage.getItem('va-disable')) {
+            return null;
+          }
+          return event;
+        }}
+      />
     </div>
   )
 }

--- a/components/elements/banner/consent.tsx
+++ b/components/elements/banner/consent.tsx
@@ -1,0 +1,52 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export default function ConsentBanner() {
+
+  const [showConsentBanner, setShowConsentBanner] = useState(false)
+
+  useEffect(() => {
+    if (!(localStorage.getItem('va-disable') /* || (localStorage.getItem('va-disable') == 'true') */ )) {
+      setShowConsentBanner(true);
+    }
+  }, []);
+
+  if (!showConsentBanner) {
+    return null
+  }
+
+  const acceptCookies = () => { 
+    // posthog.opt_in_capturing();
+    localStorage.removeItem('va-disable');
+    setShowConsentBanner(false);
+  };
+  
+  const declineCookies = () => {
+    // posthog.opt_out_capturing();
+    localStorage.setItem('va-disable', 'true')
+    setShowConsentBanner(false);
+  };
+
+  return (
+    <div>
+      <p>
+        We use tracking cookies to understand how you use 
+        the product and help us improve it.
+        Please accept cookies to help us improve.
+      </p>
+      <button 
+        type="button"
+        onClick={acceptCookies}
+      >
+        Accept cookies
+      </button>
+      <span> </span>
+      <button 
+        type="button"
+        onClick={declineCookies}
+      >
+        Decline cookies
+      </button>
+    </div>
+  )
+}

--- a/components/elements/index.tsx
+++ b/components/elements/index.tsx
@@ -6,6 +6,7 @@ import Footer from '@/components/elements/footer/footer'
 import Header from '@/components/elements/header/header'
 import Main from '@/components/elements/main/main'
 import Nav from '@/components/elements/nav/nav'
+import ConsentBanner from '@/components/elements/banner/consent'
 
 export {
   Article,
@@ -13,5 +14,6 @@ export {
   Footer,
   Header,
   Main,
-  Nav
+  Nav,
+  ConsentBanner
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Consent opt-out of Vercel Analytics by setting/getting/checking for 'va-disable' in local storage.

Had to move analytics component into the consent handler for this to work, and also have no styles applied to the banner right now.

As is (too?) often the case, unfortunately this needs to be on prod to be able to fully test it...