### PR TITLE
Development/fetch-test

### DIFF
--- a/app/login/login.tsx
+++ b/app/login/login.tsx
@@ -2,6 +2,9 @@ import Link from 'next/link'
 import { headers, cookies } from 'next/headers'
 import { createClient } from '@/utils/supabase/server'
 import { redirect } from 'next/navigation'
+import { Turnstile } from '@marsidev/react-turnstile'
+import { useState } from 'react'
+import { turnstileSiteKey } from '@/utils/captcha/turnstile'
 import styles from '@/app/layout.module.css'
 
 export default function Login({
@@ -9,6 +12,10 @@ export default function Login({
 }: {
   searchParams: { message: string }
 }) {
+
+  const sitekey = turnstileSiteKey()
+
+  const [captchaToken, setCaptchaToken] = useState<string>()
 
   const cookieStore = cookies()
 
@@ -58,6 +65,7 @@ export default function Login({
       email,
       password,
       options: {
+        captchaToken,
         emailRedirectTo: `${origin}/auth/callback`,
       },
     })
@@ -131,6 +139,10 @@ export default function Login({
               >
                 Sign Up
               </button>
+              <Turnstile
+                siteKey={`${sitekey}`}
+                onSuccess={(token) => { setCaptchaToken(token) }}
+              />
               {searchParams?.message && (
                 <p className="mt-4 p-4 bg-foreground/10 text-foreground text-center">
                   {searchParams.message}

--- a/app/login/login.tsx
+++ b/app/login/login.tsx
@@ -2,9 +2,9 @@ import Link from 'next/link'
 import { headers, cookies } from 'next/headers'
 import { createClient } from '@/utils/supabase/server'
 import { redirect } from 'next/navigation'
-import { Turnstile } from '@marsidev/react-turnstile'
-import { useState } from 'react'
-import { turnstileSiteKey } from '@/utils/captcha/turnstile'
+// import { Turnstile } from '@marsidev/react-turnstile'
+// import { useState } from 'react'
+// import { turnstileSiteKey } from '@/utils/captcha/turnstile'
 import styles from '@/app/layout.module.css'
 
 export default function Login({
@@ -13,9 +13,9 @@ export default function Login({
   searchParams: { message: string }
 }) {
 
-  const sitekey = turnstileSiteKey()
+  // const sitekey = turnstileSiteKey()
 
-  const [captchaToken, setCaptchaToken] = useState<string>()
+  // const [captchaToken, setCaptchaToken] = useState<string>()
 
   const cookieStore = cookies()
 
@@ -65,7 +65,7 @@ export default function Login({
       email,
       password,
       options: {
-        captchaToken,
+        // captchaToken,
         emailRedirectTo: `${origin}/auth/callback`,
       },
     })
@@ -130,7 +130,7 @@ export default function Login({
                 placeholder="••••••••"
                 required
               />
-              <button className="bg-green-700 rounded-md px-4 py-2 text-foreground mb-2">
+              <button className="bg-green-500 hover:bg-purple-500 rounded-lg px-4 py-2 text-foreground mb-2">
                 Sign In
               </button>
               <button
@@ -139,10 +139,10 @@ export default function Login({
               >
                 Sign Up
               </button>
-              <Turnstile
+              {/* <Turnstile
                 siteKey={`${sitekey}`}
                 onSuccess={(token) => { setCaptchaToken(token) }}
-              />
+              /> */}
               {searchParams?.message && (
                 <p className="mt-4 p-4 bg-foreground/10 text-foreground text-center">
                   {searchParams.message}

--- a/app/projects/fetch/fetch_content.tsx
+++ b/app/projects/fetch/fetch_content.tsx
@@ -1,0 +1,89 @@
+import { MDXRemote } from 'next-mdx-remote/rsc'
+import {
+  HRGradient,
+  BackToHome,
+  BackToTop
+} from '@/components/layouts'
+import { Article } from '@/components/elements'
+import styles from '@/app/layout.module.css'
+
+export const dynamic = 'force-dynamic'
+
+export default async function FetchContent() {
+
+  // // MDX text - can be from a local file, database, CMS, fetch, anywhere...
+  // const res = await fetch('https://raw.githubusercontent.com/nathanjhood/Biquads/main/README.md')
+  // const markdown = await res.text()
+
+  try {
+
+    // Simple typo to test error...
+    const res = await fetch('https://raw.githubusercontent.com/nathanjhood/Biquads/main/READEM.md')
+    const markdown = await res.text()
+
+    return (
+      <Article>
+        <div className={styles.container}>
+
+          <div className={styles.content}>
+
+            <div className={styles.flexboxgrid}>
+
+              {/* <div className='flex justify-center align-middle'>
+                <MDXRemote source={`[![Biquads](https://github-readme-stats-two-lime-18.vercel.app/api/pin/?username=nathanjhood\&repo=Biquads\&theme=transparent)](https://github.com/nathanjhood/Biquads)`} />
+              </div> */}
+
+              <HRGradient />
+
+              <MDXRemote source={markdown} />
+
+              <HRGradient />
+
+              <BackToTop />
+
+              <BackToHome />
+
+              <HRGradient />
+
+            </div>
+          </div>
+        </div>
+      </Article>
+    )
+  } catch (error) {
+
+    // TypeError: Failed to fetch
+    console.log('Failed to fetch content:', error);
+    const markdown = `# 404: not found due to ${error}`
+
+    return (
+      <Article>
+        <div className={styles.container}>
+
+          <div className={styles.content}>
+
+            <div className={styles.flexboxgrid}>
+
+              {/* <div className='flex justify-center align-middle'>
+                <MDXRemote source={`[![Biquads](https://github-readme-stats-two-lime-18.vercel.app/api/pin/?username=nathanjhood\&repo=Biquads\&theme=transparent)](https://github.com/nathanjhood/Biquads)`} />
+              </div> */}
+
+              <HRGradient />
+
+              <MDXRemote source={markdown} />
+
+              <HRGradient />
+
+              <BackToTop />
+
+              <BackToHome />
+
+              <HRGradient />
+
+            </div>
+          </div>
+        </div>
+      </Article>
+    )
+  }
+}

--- a/app/projects/fetch/page.tsx
+++ b/app/projects/fetch/page.tsx
@@ -1,0 +1,18 @@
+import FetchContent from '@/app/projects/fetch/fetch_content'
+import { Metadata } from 'next'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Fetch',
+  description: 'Asyncronous Fetch API tests.',
+  alternates: {
+    canonical: 'https://www.stoneydsp.com/projects/fetch'
+  }
+}
+
+export default async function FetchPage() {
+  return (
+    <FetchContent />
+  )
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "wipe": "yarn clean && rm -rvf node_modules"
   },
   "dependencies": {
+    "@marsidev/react-turnstile": "^0.3.2",
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
     "@next/mdx": "^14.0.1",

--- a/utils/captcha/turnstile.ts
+++ b/utils/captcha/turnstile.ts
@@ -1,0 +1,6 @@
+export const turnstileSiteKey = () => { 
+  const key = process.env.TURNSTILE_SITE_KEY
+  ? `${process.env.TURNSTILE_SITE_KEY}`
+  : ''
+  return key
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,6 +114,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@marsidev/react-turnstile@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@marsidev/react-turnstile/-/react-turnstile-0.3.2.tgz#8811a63b64c0b4bd0a3fdd6ff7efaa1c524ed6ed"
+  integrity sha512-NTTmQdVgSFTHZlFRw/6RwG2kveT6J57U8JdjhbSdKcSBEbhqoe9L3wPMbq8g31KCDOm2cYTu/LNavAPbCY1vgA==
+
 "@mdx-js/loader@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@mdx-js/loader/-/loader-3.0.0.tgz#87ccefb0cd9d37be2aecf939be0a8d3f364eec84"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Initial try/catch implementation for MDX pages.

## What is the current behavior?

Currently the implementation assumes that 'fetch()' will return the README.md content from my source repos successfully. Failure to do so is currently undefined behaviour.

## What is the new behavior?

Try the fetch-and-return-jsx-element (basically the entire page at the moment). If error, replace the content with a simple 404 (written in markdown) and console log the error.