### PR TITLE
Update generate-sitemap.mjs

### DIFF
--- a/internals/generate-sitemap.mjs
+++ b/internals/generate-sitemap.mjs
@@ -31,7 +31,7 @@ async function generate() {
 
 				return `
 					<url>
-						<loc>${`https://www.stoneydsp.com${route}`}</loc>
+						<loc>${`https://stoneydsp.com${route}`}</loc>
 					</url>`
 						})
 						.join('')}


### PR DESCRIPTION
Sitemap links should match canonical links in page meta data for SEO.